### PR TITLE
fix: parent invite and dashboard loading

### DIFF
--- a/src/app/api/invite/create-for-child/route.ts
+++ b/src/app/api/invite/create-for-child/route.ts
@@ -27,7 +27,8 @@ export async function POST(request: NextRequest) {
   const data = wishlistSnap.data()!;
   const isOwner = data.childUid === decoded.uid;
   const isViewer = Array.isArray(data.viewerUids) && data.viewerUids.includes(decoded.uid);
-  if (!isOwner && !isViewer) {
+  const isParent = Array.isArray(data.parentUids) && data.parentUids.includes(decoded.uid);
+  if (!isOwner && !isViewer && !isParent) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -75,27 +75,35 @@ export default function DashboardPage() {
   useEffect(() => {
     if (loading || !user) return;
 
-    const unsubParent = subscribeToParentWishlists(user.uid, (newLists, fromCache) => {
-      setParentWishlists(newLists);
-      if (!fromCache || newLists.length > 0) {
-        setParentDataLoading(false);
-      }
-      newLists.forEach((wl) => {
-        fetchChildName(wl.childUid);
-        subscribeToStats(wl.id);
-      });
-    });
+    const unsubParent = subscribeToParentWishlists(
+      user.uid,
+      (newLists, fromCache) => {
+        setParentWishlists(newLists);
+        if (!fromCache || newLists.length > 0) {
+          setParentDataLoading(false);
+        }
+        newLists.forEach((wl) => {
+          fetchChildName(wl.childUid);
+          subscribeToStats(wl.id);
+        });
+      },
+      () => setParentDataLoading(false)
+    );
 
-    const unsubViewer = subscribeToViewerWishlists(user.uid, (newLists, fromCache) => {
-      setViewerWishlists(newLists);
-      if (!fromCache || newLists.length > 0) {
-        setViewerDataLoading(false);
-      }
-      newLists.forEach((wl) => {
-        fetchChildName(wl.childUid);
-        subscribeToStats(wl.id);
-      });
-    });
+    const unsubViewer = subscribeToViewerWishlists(
+      user.uid,
+      (newLists, fromCache) => {
+        setViewerWishlists(newLists);
+        if (!fromCache || newLists.length > 0) {
+          setViewerDataLoading(false);
+        }
+        newLists.forEach((wl) => {
+          fetchChildName(wl.childUid);
+          subscribeToStats(wl.id);
+        });
+      },
+      () => setViewerDataLoading(false)
+    );
 
     return () => {
       unsubParent();

--- a/src/lib/firebase/viewer.ts
+++ b/src/lib/firebase/viewer.ts
@@ -11,7 +11,8 @@ import type { WishlistDoc, PurchaseStatusDoc, ActivityLogDoc } from '@/types/fir
 // state until fromCache=false arrives (the confirmed network result).
 export function subscribeToViewerWishlists(
   viewerUid: string,
-  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void
+  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void,
+  onError?: () => void
 ): () => void {
   const q = query(
     collection(db, 'wishlists'),
@@ -23,14 +24,15 @@ export function subscribeToViewerWishlists(
       ...d.data() as Omit<WishlistDoc, 'id'>,
     }));
     onWishlists(lists, snap.metadata.fromCache);
-  });
+  }, () => { onError?.(); });
 }
 
 // D-10: Subscribe to all wishlists the user has parent-level access to.
 // Uses array-contains query on parentUids — no composite index required (single field).
 export function subscribeToParentWishlists(
   parentUid: string,
-  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void
+  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void,
+  onError?: () => void
 ): () => void {
   const q = query(
     collection(db, 'wishlists'),
@@ -42,7 +44,7 @@ export function subscribeToParentWishlists(
       ...d.data() as Omit<WishlistDoc, 'id'>,
     }));
     onWishlists(lists, snap.metadata.fromCache);
-  });
+  }, () => { onError?.(); });
 }
 
 // VIEW-01, VIEW-05: Subscribe to purchaseStatus subcollection.


### PR DESCRIPTION
## Summary

- `api/invite/create-for-child` returnerade 403 för föräldrar — routen kontrollerade `isViewer` men föräldrar sitter i `parentUids[]`, inte `viewerUids[]`. Fixat genom att lägga till `isParent`-kontroll.
- Dashboard fastnade på "Laddar…" om Firestore-subscriptions fick permission-denied (t.ex. innan regler deployats) — `subscribeToParentWishlists` och `subscribeToViewerWishlists` saknade felhantering. Lade till `onError`-callbacks som sätter loading till `false`.

## Påverkade filer

- `src/app/api/invite/create-for-child/route.ts`
- `src/lib/firebase/viewer.ts`
- `src/app/dashboard/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)