### PR TITLE
fix: remove unused Geist Mono font

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
 import { OfflineBanner } from "@/components/OfflineBanner";
@@ -7,11 +7,6 @@ import { UpdateToast } from "@/components/UpdateToast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 
@@ -32,7 +27,7 @@ export default function RootLayout({
   return (
     <html
       lang="sv"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <OfflineBanner />


### PR DESCRIPTION
`Geist_Mono` laddades i layout men användes inte någonstans i appen. Next.js preloadade ändå fonten vilket överfyllde konsolen med varningar och onödig nätverkstrafik.

Tar bort `Geist_Mono`-importen och CSS-variabeln från `<html>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)