### PR TITLE
Fix account creation and invitation bugs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,14 +14,25 @@ const withPWAConfig = withPWA({
   workboxOptions: {
     disableDevLogs: true,
     runtimeCaching: [
-      // Override the default "pages" cache to add a 3-second timeout.
-      // Without this, NetworkFirst waits indefinitely — causing slow loads on Vercel cold starts.
+      // Most-specific rules must come first — Workbox uses the first matching rule.
+      // Override the "pages-rsc-prefetch" cache (RSC prefetch fetches) with a timeout.
       {
-        urlPattern: ({ url: { pathname }, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
-          sameOrigin && !pathname.startsWith("/api/"),
+        urlPattern: ({
+          request,
+          url: { pathname },
+          sameOrigin,
+        }: {
+          request: Request;
+          url: URL;
+          sameOrigin: boolean;
+        }) =>
+          request.headers.get("RSC") === "1" &&
+          request.headers.get("Next-Router-Prefetch") === "1" &&
+          sameOrigin &&
+          !pathname.startsWith("/api/"),
         handler: "NetworkFirst" as const,
         options: {
-          cacheName: "pages",
+          cacheName: "pages-rsc-prefetch",
           networkTimeoutSeconds: 3,
         },
       },
@@ -45,24 +56,14 @@ const withPWAConfig = withPWA({
           networkTimeoutSeconds: 3,
         },
       },
-      // Override the "pages-rsc-prefetch" cache (RSC prefetch fetches) with a timeout.
+      // Catch-all for regular page navigations (no RSC headers).
+      // Without this, NetworkFirst waits indefinitely — causing slow loads on Vercel cold starts.
       {
-        urlPattern: ({
-          request,
-          url: { pathname },
-          sameOrigin,
-        }: {
-          request: Request;
-          url: URL;
-          sameOrigin: boolean;
-        }) =>
-          request.headers.get("RSC") === "1" &&
-          request.headers.get("Next-Router-Prefetch") === "1" &&
-          sameOrigin &&
-          !pathname.startsWith("/api/"),
+        urlPattern: ({ url: { pathname }, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+          sameOrigin && !pathname.startsWith("/api/"),
         handler: "NetworkFirst" as const,
         options: {
-          cacheName: "pages-rsc-prefetch",
+          cacheName: "pages",
           networkTimeoutSeconds: 3,
         },
       },

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { use, useEffect, useState } from 'react';
+import { use, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   signInWithEmailAndPassword,
@@ -50,11 +50,14 @@ function InlineAuthForm({
       }
       onSuccess();
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Något gick fel. Försök igen.';
+      // Firebase v9+ uses err.code (e.g. "auth/invalid-credential") not err.message substrings.
+      const code = (err as { code?: string }).code ?? '';
       setError(
-        msg.includes('wrong-password') || msg.includes('user-not-found')
+        code === 'auth/invalid-credential' ||
+        code === 'auth/wrong-password' ||
+        code === 'auth/user-not-found'
           ? 'Fel e-post eller lösenord.'
-          : msg.includes('email-already-in-use')
+          : code === 'auth/email-already-in-use'
           ? 'Det finns redan ett konto med den e-postadressen.'
           : 'Något gick fel. Försök igen.'
       );
@@ -125,12 +128,20 @@ export default function InvitePage({
 
   const [pageState, setPageState] = useState<PageState>('loading');
   const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
+  // Guard: only let useEffect trigger redeemToken on the initial auth state resolution.
+  // If auth happens via the inline form (login or register), handleAuthSuccess calls
+  // redeemToken explicitly instead — preventing a race where onIdTokenChanged fires
+  // mid-form and triggers redemption before set-viewer-claim has completed.
+  const initialAuthCheckedRef = useRef(false);
 
   // After auth state resolves, determine what to show
   useEffect(() => {
     if (loading) return;
+    if (initialAuthCheckedRef.current) return;
+    initialAuthCheckedRef.current = true;
+
     if (user) {
-      // User is logged in — attempt redemption immediately
+      // User was already logged in when the page loaded — attempt redemption immediately
       setPageState('joining');
       redeemToken();
     } else {
@@ -176,8 +187,11 @@ export default function InvitePage({
   }
 
   function handleAuthSuccess() {
-    // After login/register, user state updates → useEffect fires → redeemToken()
-    // No explicit action needed here; the useEffect dependency on `user` handles it
+    // Called after the inline form completes login or registration (including set-viewer-claim).
+    // We drive redemption explicitly here instead of relying on useEffect, which is guarded
+    // to only run once on initial load to avoid a race with set-viewer-claim.
+    setPageState('joining');
+    redeemToken();
   }
 
   if (pageState === 'loading' || loading || pageState === 'joining') {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -31,6 +31,10 @@ export default function RegisterPage() {
       });
 
       if (!response.ok) {
+        // Roll back: delete the Auth account so the user can retry with the same email.
+        // Without this, a failed claim-set leaves an orphaned account with no role,
+        // and the next attempt fails with "email-already-in-use".
+        await credential.user.delete().catch(() => {});
         setError('Registreringen misslyckades, försök igen');
         return;
       }

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { onAuthStateChanged, User } from 'firebase/auth';
+import { onIdTokenChanged, User } from 'firebase/auth';
 import { auth } from '@/lib/firebase/client';
 
 interface AuthContextValue {
@@ -21,7 +21,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+    // onIdTokenChanged fires on sign-in, sign-out, AND token refreshes (getIdToken(true)).
+    // This ensures role is always current after invite redemption or claim changes.
+    const unsubscribe = onIdTokenChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
         // Read role from ID token custom claims
         const idTokenResult = await firebaseUser.getIdTokenResult();


### PR DESCRIPTION
- register/page.tsx: delete orphaned Firebase Auth account when
  set-parent-claim fails, so the user can retry with the same email
  instead of hitting "email-already-in-use" on the next attempt

- AuthProvider.tsx: switch from onAuthStateChanged to onIdTokenChanged
  so the role in context is refreshed whenever getIdToken(true) is
  called (e.g. after invite redemption), not only on sign-in/sign-out

- invite/[token]/page.tsx: fix race condition where onIdTokenChanged
  fired mid-registration and triggered redeemToken() before
  set-viewer-claim had completed; useEffect is now guarded to run only
  once on initial load, and handleAuthSuccess drives redemption
  explicitly after the form finishes

- invite/[token]/page.tsx: fix Firebase error code detection in
  InlineAuthForm — Firebase v12 uses auth/invalid-credential, not the
  legacy auth/wrong-password or auth/user-not-found codes; use
  err.code instead of message substring matching

- next.config.ts: fix Workbox runtime caching rule ordering — the
  general pages rule was listed first and always matched, making the
  more-specific RSC rules dead code; moved RSC prefetch and RSC
  navigation rules before the catch-all so they use their own cache
  buckets as intended

https://claude.ai/code/session_01N5do2T9zZmA7zFPCs7AXtX