### PR TITLE
Fix account creation, invitation and dashboard loading bugs

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -77,11 +77,9 @@ export default function DashboardPage() {
 
     const unsubParent = subscribeToParentWishlists(
       user.uid,
-      (newLists, fromCache) => {
+      (newLists) => {
         setParentWishlists(newLists);
-        if (!fromCache || newLists.length > 0) {
-          setParentDataLoading(false);
-        }
+        setParentDataLoading(false);
         newLists.forEach((wl) => {
           fetchChildName(wl.childUid);
           subscribeToStats(wl.id);
@@ -92,11 +90,9 @@ export default function DashboardPage() {
 
     const unsubViewer = subscribeToViewerWishlists(
       user.uid,
-      (newLists, fromCache) => {
+      (newLists) => {
         setViewerWishlists(newLists);
-        if (!fromCache || newLists.length > 0) {
-          setViewerDataLoading(false);
-        }
+        setViewerDataLoading(false);
         newLists.forEach((wl) => {
           fetchChildName(wl.childUid);
           subscribeToStats(wl.id);

--- a/src/lib/firebase/viewer.ts
+++ b/src/lib/firebase/viewer.ts
@@ -7,23 +7,21 @@ import type { WishlistDoc, PurchaseStatusDoc, ActivityLogDoc } from '@/types/fir
 
 // VIEW-06: Subscribe to all wishlists the viewer has access to.
 // Uses array-contains query on viewerUids — requires no composite index (single field).
-// fromCache=true means the result came from local IndexedDB — caller should stay in loading
-// state until fromCache=false arrives (the confirmed network result).
 export function subscribeToViewerWishlists(
   viewerUid: string,
-  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void,
+  onWishlists: (wishlists: WishlistDoc[]) => void,
   onError?: () => void
 ): () => void {
   const q = query(
     collection(db, 'wishlists'),
     where('viewerUids', 'array-contains', viewerUid)
   );
-  return onSnapshot(q, { includeMetadataChanges: true }, (snap) => {
+  return onSnapshot(q, (snap) => {
     const lists = snap.docs.map((d) => ({
       id: d.id,
       ...d.data() as Omit<WishlistDoc, 'id'>,
     }));
-    onWishlists(lists, snap.metadata.fromCache);
+    onWishlists(lists);
   }, () => { onError?.(); });
 }
 
@@ -31,19 +29,19 @@ export function subscribeToViewerWishlists(
 // Uses array-contains query on parentUids — no composite index required (single field).
 export function subscribeToParentWishlists(
   parentUid: string,
-  onWishlists: (wishlists: WishlistDoc[], fromCache: boolean) => void,
+  onWishlists: (wishlists: WishlistDoc[]) => void,
   onError?: () => void
 ): () => void {
   const q = query(
     collection(db, 'wishlists'),
     where('parentUids', 'array-contains', parentUid)
   );
-  return onSnapshot(q, { includeMetadataChanges: true }, (snap) => {
+  return onSnapshot(q, (snap) => {
     const lists = snap.docs.map((d) => ({
       id: d.id,
       ...d.data() as Omit<WishlistDoc, 'id'>,
     }));
-    onWishlists(lists, snap.metadata.fromCache);
+    onWishlists(lists);
   }, () => { onError?.(); });
 }
 


### PR DESCRIPTION
## Summary

- **Orphaned account på register**: Om `set-parent-claim` misslyckades skapades ett Firebase Auth-konto utan roll som sedan blockerade ny registrering med "e-postadressen används redan". Fixat med `credential.user.delete()` som rollback.

- **Inaktuell roll i AuthProvider**: `onAuthStateChanged` triggas inte av `getIdToken(true)`, vilket innebar att `role` i context förblev `null` efter inbjudningslösning tills nästa inloggning. Bytt till `onIdTokenChanged` som triggas på token-refresh.

- **Race condition i invite-sidan**: Vid ny registrering via inbjudningslänk triggades `redeemToken()` av `onIdTokenChanged` medan formuläret fortfarande väntade på `set-viewer-claim`. Fixat med `initialAuthCheckedRef` som spärrar `useEffect` efter initial laddning — `handleAuthSuccess` anropar nu `redeemToken()` explicit.

- **Workbox-regler i fel ordning**: Den generella page-regeln stod först och matchade alltid, vilket gjorde RSC-reglerna till dead code. Specifika regler (RSC prefetch, RSC navigation) flyttade till toppen.

- **Firebase-felkodsdetektion i InlineAuthForm**: Felkoder kontrollerades med substring-matching på `.message`. Firebase v12 returnerar `auth/invalid-credential` — bytt till `.code`-jämförelse.

- **Dashboard fastnar på "Laddar…"**: `parentDataLoading`/`viewerDataLoading` väntade på `fromCache: false` för att resas ned. För användare utan önskelistor (empty result) kunde nätverkssnapshot dröja länge (Vercel cold start) och låsa sidan på "Laddar…" på obestämd tid. Loading sätts nu till `false` på första snapshot oavsett källa.

## Test plan

- [ ] Registrera nytt konto — misslyckas `set-parent-claim` ska samma e-post kunna användas igen direkt
- [ ] Logga in och lös in en viewer-inbjudningslänk — rollen ska visas korrekt direkt utan omstart
- [ ] Lös in en föräldra-inbjudningslänk — rollen ska uppgraderas direkt i UI
- [ ] Registrera via inbjudningslänk — ska fungera utan race condition
- [ ] Logga in på dashboard utan några barn/önskelistor — ska visa tomt tillstånd direkt, inte spinna
- [ ] Logga in på dashboard med befintliga önskelistor — ska visas normalt

https://claude.ai/code/session_01N5do2T9zZmA7zFPCs7AXtX