### PR TITLE
Fix AuthProvider race condition from onIdTokenChanged

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -124,7 +124,7 @@ export default function InvitePage({
 }) {
   const { token } = use(params);
   const router = useRouter();
-  const { user, loading } = useAuth();
+  const { user, loading, refreshRole } = useAuth();
 
   const [pageState, setPageState] = useState<PageState>('loading');
   const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
@@ -177,9 +177,10 @@ export default function InvitePage({
         return;
       }
 
-      // Force-refresh token so new viewer claim is available to Firestore rules
-      // Pattern from register/page.tsx
+      // Force-refresh token so new claim is available to Firestore rules, then
+      // sync the updated role into AuthProvider context via refreshRole().
       await auth.currentUser?.getIdToken(/* forceRefresh = */ true);
+      await refreshRole();
       router.push(`/viewer/${data.wishlistId}`);
     } catch {
       setPageState('error');

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,18 +1,20 @@
 'use client';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { onIdTokenChanged, User } from 'firebase/auth';
+import { onAuthStateChanged, User } from 'firebase/auth';
 import { auth } from '@/lib/firebase/client';
 
 interface AuthContextValue {
   user: User | null;
   role: string | null;
   loading: boolean;
+  refreshRole: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   role: null,
   loading: true,
+  refreshRole: async () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -21,11 +23,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // onIdTokenChanged fires on sign-in, sign-out, AND token refreshes (getIdToken(true)).
-    // This ensures role is always current after invite redemption or claim changes.
-    const unsubscribe = onIdTokenChanged(auth, async (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
-        // Read role from ID token custom claims
         const idTokenResult = await firebaseUser.getIdTokenResult();
         setRole((idTokenResult.claims['role'] as string) ?? null);
         setUser(firebaseUser);
@@ -38,8 +37,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => unsubscribe();
   }, []);
 
+  // Call this after getIdToken(true) to sync the new claim into context without
+  // triggering a full auth-state re-evaluation or risking concurrent handler races.
+  async function refreshRole() {
+    if (!auth.currentUser) return;
+    const result = await auth.currentUser.getIdTokenResult();
+    setRole((result.claims['role'] as string) ?? null);
+  }
+
   return (
-    <AuthContext.Provider value={{ user, role, loading }}>
+    <AuthContext.Provider value={{ user, role, loading, refreshRole }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary

- **Återgår från `onIdTokenChanged` till `onAuthStateChanged`** — `onIdTokenChanged` triggades vid varje token-ändring under registreringsflödet, vilket orsakade två parallella handlers som racade om att skriva `role` i context. Handler utan claim kunde vinna och sätta `role = null` trots att `parent`-claimet var korrekt satt — registrering och onboarding fastnade.

- **Ny `refreshRole()`-funktion i `AuthProvider`** — exponeras via context och anropas explicit av invite-sidan efter `getIdToken(true)`, utan att riskera concurrent handler-races.

## Test plan

- [ ] Registrera nytt föräldrakonto — ska redirecta till onboarding utan att fastna på "Laddar…"
- [ ] Slutför onboarding (skapa barn, namnge önskelista) — ska fungera utan spinner
- [ ] Lös in viewer-inbjudningslänk — rollen ska visas korrekt direkt
- [ ] Lös in föräldra-inbjudningslänk — rollen ska uppgraderas direkt i UI
- [ ] Kontrollera att dashboard laddar snabbt utan att fastna

https://claude.ai/code/session_01N5do2T9zZmA7zFPCs7AXtX