### PR TITLE
fix: barnkonton hamnar nu hos föräldern efter registrering

### DIFF
--- a/src/app/api/auth/register-child/route.ts
+++ b/src/app/api/auth/register-child/route.ts
@@ -13,9 +13,9 @@ export async function POST(request: NextRequest) {
     viewerIdToken?: string;
   };
 
-  if (!username || !password || !displayName) {
+  if (!username || !password || !displayName || !viewerIdToken) {
     return NextResponse.json(
-      { error: 'username, password, and displayName required' },
+      { error: 'username, password, displayName, and viewerIdToken required' },
       { status: 400 },
     );
   }
@@ -94,10 +94,11 @@ export async function POST(request: NextRequest) {
   let parentUids: string[] = [];
   if (viewerIdToken) {
     try {
-      const decoded = await adminAuth.verifyIdToken(viewerIdToken);
+      // checkRevoked:false avoids a Firestore roundtrip and tolerates slight clock skew
+      const decoded = await adminAuth.verifyIdToken(viewerIdToken, false);
       parentUids = [decoded.uid];
-    } catch {
-      // Invalid token — proceed without parent (non-fatal)
+    } catch (err) {
+      console.error('[register-child] verifyIdToken failed — parentUids will be empty:', err);
     }
   }
   batch.set(adminDb.collection('wishlists').doc(userRecord.uid), {

--- a/src/components/onboarding/ChildAccountForm.tsx
+++ b/src/components/onboarding/ChildAccountForm.tsx
@@ -39,9 +39,14 @@ export function ChildAccountForm({ onSuccess }: ChildAccountFormProps) {
 
     setLoading(true);
     try {
-      let viewerIdToken: string | undefined;
+      if (!auth.currentUser) {
+        setError('Sessionen har gått ut. Logga ut och logga in igen, sedan försök skapa barnkontot.');
+        setLoading(false);
+        return;
+      }
+      let viewerIdToken: string;
       try {
-        viewerIdToken = await auth.currentUser?.getIdToken(true);
+        viewerIdToken = await auth.currentUser.getIdToken(true);
       } catch {
         setError('Sessionen har gått ut. Logga ut och logga in igen, sedan försök skapa barnkontot.');
         setLoading(false);
@@ -55,7 +60,7 @@ export function ChildAccountForm({ onSuccess }: ChildAccountFormProps) {
           password,
           displayName: displayName.trim(),
           age: ageNum,
-          ...(viewerIdToken ? { viewerIdToken } : {}),
+          viewerIdToken,
         }),
       });
       if (res.status === 409) {

--- a/tests/api/auth/register-child.test.ts
+++ b/tests/api/auth/register-child.test.ts
@@ -37,9 +37,12 @@ const mockAdminDb = {
 const mockCreateUser = jest.fn();
 const mockSetCustomUserClaims = jest.fn();
 
+const mockVerifyIdToken = jest.fn();
+
 const mockAdminAuth = {
   createUser: mockCreateUser,
   setCustomUserClaims: mockSetCustomUserClaims,
+  verifyIdToken: mockVerifyIdToken,
 };
 
 jest.mock('@/lib/firebase/admin', () => ({
@@ -94,22 +97,33 @@ describe('POST /api/auth/register-child', () => {
     mockBatchSet.mockReturnValue(undefined);
     mockBatchCommit.mockResolvedValue(undefined);
     mockDocDelete.mockResolvedValue(undefined);
+    mockVerifyIdToken.mockResolvedValue({ uid: 'uid-parent' });
   });
 
+  const validBody = { username: 'alice', password: 'pass123', displayName: 'Alice', age: 10, viewerIdToken: 'tok' };
+
   it('returns 400 when username is missing', async () => {
-    const req = makeRequest({ password: 'pass123' });
+    const req = makeRequest({ password: 'pass123', viewerIdToken: 'tok' });
     const res = await POST(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe('username, password, and displayName required');
+    expect(body.error).toBe('username, password, displayName, and viewerIdToken required');
   });
 
   it('returns 400 when password is missing', async () => {
-    const req = makeRequest({ username: 'alice' });
+    const req = makeRequest({ username: 'alice', viewerIdToken: 'tok' });
     const res = await POST(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe('username, password, and displayName required');
+    expect(body.error).toBe('username, password, displayName, and viewerIdToken required');
+  });
+
+  it('returns 400 when viewerIdToken is missing', async () => {
+    const req = makeRequest({ username: 'alice', password: 'pass123', displayName: 'Alice', age: 10 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('username, password, displayName, and viewerIdToken required');
   });
 
   it('returns 400 when body is empty', async () => {
@@ -117,11 +131,11 @@ describe('POST /api/auth/register-child', () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe('username, password, and displayName required');
+    expect(body.error).toBe('username, password, displayName, and viewerIdToken required');
   });
 
   it('normalises username to lowercase before creating account', async () => {
-    const req = makeRequest({ username: 'ALICE', password: 'pass123', displayName: 'Alice', age: 10 });
+    const req = makeRequest({ ...validBody, username: 'ALICE' });
     await POST(req);
     expect(mockCreateUser).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'alice@wishlist.internal' }),
@@ -129,7 +143,7 @@ describe('POST /api/auth/register-child', () => {
   });
 
   it('returns 201 with uid on success', async () => {
-    const req = makeRequest({ username: 'alice', password: 'pass123', displayName: 'Alice', age: 10 });
+    const req = makeRequest(validBody);
     const res = await POST(req);
     expect(res.status).toBe(201);
     const body = await res.json();
@@ -137,14 +151,24 @@ describe('POST /api/auth/register-child', () => {
   });
 
   it('sets role claim to child after creating user', async () => {
-    const req = makeRequest({ username: 'alice', password: 'pass123', displayName: 'Alice', age: 10 });
+    const req = makeRequest(validBody);
     await POST(req);
     expect(mockSetCustomUserClaims).toHaveBeenCalledWith('uid-alice', { role: 'child' });
   });
 
+  it('sets parentUids with verified parent uid on success', async () => {
+    const req = makeRequest(validBody);
+    await POST(req);
+    expect(mockVerifyIdToken).toHaveBeenCalledWith('tok', false);
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ parentUids: ['uid-parent'] }),
+    );
+  });
+
   it('returns 409 when username is already taken (transaction throws)', async () => {
     mockRunTransaction.mockRejectedValue(new Error('USERNAME_TAKEN'));
-    const req = makeRequest({ username: 'alice', password: 'pass123', displayName: 'Alice', age: 10 });
+    const req = makeRequest(validBody);
     const res = await POST(req);
     expect(res.status).toBe(409);
     const body = await res.json();
@@ -153,7 +177,7 @@ describe('POST /api/auth/register-child', () => {
 
   it('returns 409 when Firebase Auth reports email-already-exists', async () => {
     mockCreateUser.mockRejectedValue({ code: 'auth/email-already-exists' });
-    const req = makeRequest({ username: 'alice', password: 'pass123', displayName: 'Alice', age: 10 });
+    const req = makeRequest(validBody);
     const res = await POST(req);
     expect(res.status).toBe(409);
     const body = await res.json();


### PR DESCRIPTION
## Summary

- `auth.currentUser?.getIdToken()` returnerade tyst `undefined` i produktion om Firebase Auth inte hunnit initialiseras — `viewerIdToken` skickades aldrig med
- Barnets wishlist skapades med `parentUids: []`, vilket gjorde att barnet inte syntes i förälderns dashboard
- Föräldern försökte registrera igen med samma namn → 409 (namnet redan taget i Firestore)

## Ändringar

- **route.ts**: `viewerIdToken` är nu ett obligatoriskt fält (returnerar 400 om det saknas); `verifyIdToken` loggar nu fel explicit istället för att svälja dem tyst
- **ChildAccountForm.tsx**: explicit null-check på `auth.currentUser` med tydligt felmeddelande till användaren
- **register-child.test.ts**: uppdaterade alla tester + nytt test som verifierar att `parentUids` sätts korrekt

## Test Plan

- [x] 10/10 enhetstester gröna för register-child
- [ ] Verifiera i produktion att barn dyker upp i dashboard direkt efter skapande
- [ ] Städa upp `__pending__`-dokument i Firestore `usernames`-kollektionen manuellt

🤖 Generated with [Claude Code](https://claude.com/claude-code)