### PR TITLE
fix(B-03): add onError fallback for image thumbnails

### DIFF
--- a/src/components/viewer/ViewerWishItemCard.tsx
+++ b/src/components/viewer/ViewerWishItemCard.tsx
@@ -32,6 +32,7 @@ export function ViewerWishItemCard({
 }: ViewerWishItemCardProps) {
   const [toggling, setToggling] = useState(false);
   const [toggleError, setToggleError] = useState<string | null>(null);
+  const [imageLoadError, setImageLoadError] = useState(false);
 
   const isPurchased = !!status?.purchasedBy;
   const isOwnPurchase = status?.purchasedBy === currentUid;
@@ -132,13 +133,14 @@ export function ViewerWishItemCard({
 
       {/* Right column: thumbnail */}
       <div className="flex-shrink-0">
-        {item.imageUrl ? (
+        {item.imageUrl && !imageLoadError ? (
           <img
             src={item.imageUrl}
             alt={item.title}
             width={64}
             height={64}
             className="w-16 h-16 rounded-md object-cover"
+            onError={() => setImageLoadError(true)}
           />
         ) : (
           <div className="w-16 h-16 rounded-md bg-[#E5D5CC]" aria-hidden="true" />

--- a/src/components/wishlist/WishItemCard.tsx
+++ b/src/components/wishlist/WishItemCard.tsx
@@ -17,6 +17,7 @@ interface WishItemCardProps {
 export function WishItemCard({ item, wishlistId }: WishItemCardProps) {
   const [editMode, setEditMode] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [imageLoadError, setImageLoadError] = useState(false);
 
   // Edit form state
   const [editTitle, setEditTitle] = useState('');
@@ -261,13 +262,14 @@ export function WishItemCard({ item, wishlistId }: WishItemCardProps) {
 
           {/* Right column: thumbnail + Redigera button — read mode only */}
           <div className="flex-shrink-0 flex flex-col items-end gap-2">
-            {item.imageUrl ? (
+            {item.imageUrl && !imageLoadError ? (
               <img
                 src={item.imageUrl}
                 alt={item.title}
                 width={64}
                 height={64}
                 className="w-16 h-16 rounded-md object-cover"
+                onError={() => setImageLoadError(true)}
               />
             ) : (
               <div className="w-16 h-16 rounded-md bg-[#E5D5CC]" aria-hidden="true" />


### PR DESCRIPTION
Both WishItemCard and ViewerWishItemCard already rendered imageUrl thumbnails but lacked an onError handler. A broken URL would show a browser broken-image icon instead of the soft placeholder. State-based imageLoadError now falls back to the placeholder div on load failure.

Closes #19

https://claude.ai/code/session_01UgDPphiU6dzcKaWX4aW7QJ