### PR TITLE
fix(csp): allow Firebase Auth domains in script-src + frame-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,13 +16,16 @@ const nextConfig: NextConfig = {
             value: [
               "default-src 'self'",
               // 'unsafe-eval' required in dev for React Fast Refresh (webpack HMR)
+              // apis.google.com is required by Firebase Auth Web SDK (iframe + token refresh helper)
               isDev
-                ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-                : "script-src 'self' 'unsafe-inline'",
+                ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com"
+                : "script-src 'self' 'unsafe-inline' https://apis.google.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com",
               "font-src 'self'",
+              // Firebase Auth opens an iframe at <projectId>.firebaseapp.com for popup/redirect/token flows
+              "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
               "frame-ancestors 'none'",
             ].join('; '),
           },


### PR DESCRIPTION
## Summary

Firebase Auth Web SDK loads `https://apis.google.com/js/api.js` for token refresh and uses iframes from `*.firebaseapp.com` for auth flows. The previous CSP blocked both:

- `script-src 'self' 'unsafe-inline'` blocked apis.google.com → token refresh helper failed silently
- No `frame-src` directive (default-src 'self' applied) blocked the firebaseapp.com iframe

Net effect: `auth.currentUser` had a stale token, Firestore queries on the parent dashboard returned empty results despite correct data + rules.

This commit adds:

- `https://apis.google.com` to script-src (dev + prod)
- `frame-src 'self' https://*.firebaseapp.com https://accounts.google.com`

## Test plan

- [ ] Redeploy to production after merge
- [ ] Hard-refresh dashboard, browser console should no longer show the apis.google.com CSP error
- [ ] Created child accounts should now appear under "Mina barn" on the parent dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)