### PR TITLE
fix(csp): allow connect-src to apis.google.com

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
                 : "script-src 'self' 'unsafe-inline' https://apis.google.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
-              "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com",
+              "connect-src 'self' https://*.googleapis.com https://apis.google.com https://*.firebaseio.com wss://*.firebaseio.com",
               "font-src 'self'",
               // Firebase Auth opens an iframe at <projectId>.firebaseapp.com for popup/redirect/token flows
               "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",


### PR DESCRIPTION
## Summary

Follow-up to #28. Firebase Auth's `gapi` loader sends a `gen_204` beacon to `https://apis.google.com/js/gen_204` after script load. The previous `connect-src` directive (only `*.googleapis.com`) blocked this — `apis.google.com` is a different host. The blocked beacon kept `gapi.loaded` in a retry-loop, preventing token refresh from completing, which in turn prevented the dashboard's Firestore subscription from ever being established.

Symptom: dashboard hangs in "Laddar…" for a long time then renders empty (no children shown), even when backend data is correct and rules permit the query.

## Test plan

- [ ] Verify Vercel auto-deploy after merge
- [ ] Hard-refresh dashboard, browser console should be clean (no CSP errors)
- [ ] Created child should appear under "Mina barn"

🤖 Generated with [Claude Code](https://claude.com/claude-code)