### PR TITLE
fix(invite): allow parents to manage child wishlist share links

### DIFF
--- a/src/app/api/invite/create/route.ts
+++ b/src/app/api/invite/create/route.ts
@@ -19,9 +19,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Verify caller is the wishlist owner (childUid === caller uid)
+  // Verify caller is the wishlist owner (child) or a parent
   const wishlistSnap = await adminDb.collection('wishlists').doc(wishlistId).get();
-  if (!wishlistSnap.exists || wishlistSnap.data()!.childUid !== decoded.uid) {
+  if (!wishlistSnap.exists) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const wishlistData = wishlistSnap.data()!;
+  const isOwner = wishlistData.childUid === decoded.uid;
+  const isParent = Array.isArray(wishlistData.parentUids) && wishlistData.parentUids.includes(decoded.uid);
+  if (!isOwner && !isParent) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/api/invite/current/route.ts
+++ b/src/app/api/invite/current/route.ts
@@ -18,9 +18,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Only owner can retrieve the invite token
+  // Owner (child) and parents can retrieve the invite token
   const wishlistSnap = await adminDb.collection('wishlists').doc(wishlistId).get();
-  if (!wishlistSnap.exists || wishlistSnap.data()!.childUid !== decoded.uid) {
+  if (!wishlistSnap.exists) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const data = wishlistSnap.data()!;
+  const isOwner = data.childUid === decoded.uid;
+  const isParent = Array.isArray(data.parentUids) && data.parentUids.includes(decoded.uid);
+  if (!isOwner && !isParent) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/api/invite/regenerate/route.ts
+++ b/src/app/api/invite/regenerate/route.ts
@@ -20,11 +20,17 @@ export async function POST(request: NextRequest) {
   }
 
   const wishlistSnap = await adminDb.collection('wishlists').doc(wishlistId).get();
-  if (!wishlistSnap.exists || wishlistSnap.data()!.childUid !== decoded.uid) {
+  if (!wishlistSnap.exists) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const wishlistData = wishlistSnap.data()!;
+  const isOwner = wishlistData.childUid === decoded.uid;
+  const isParent = Array.isArray(wishlistData.parentUids) && wishlistData.parentUids.includes(decoded.uid);
+  if (!isOwner && !isParent) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const oldToken: string | undefined = wishlistSnap.data()!.currentInviteToken;
+  const oldToken: string | undefined = wishlistData.currentInviteToken;
   const newToken = randomBytes(24).toString('hex');
 
   const batch = adminDb.batch();


### PR DESCRIPTION
## Summary

Settings page at \`/wishlist/[wishlistId]/settings\` is open to both child (owner) and parents, but ShareLinkPanel calls three invite routes that only accepted \`childUid === caller\`. When a parent opened a child's settings, \`/api/invite/current\` returned silent 403 — the panel rendered as if no link existed (no error visible to user, "Skapa delningslänk" knappen visades istället).

Routes updated to accept caller if either \`childUid === uid\` or \`uid in parentUids\`:
- \`GET /api/invite/current\`
- \`POST /api/invite/create\`
- \`POST /api/invite/regenerate\`

Firestore rules already permit parents to read+write the wishlist doc, so this is consistent with existing access boundaries.

## Test plan

- [ ] After deploy, log in as parent
- [ ] Open child's settings page
- [ ] Console should be clean (no 403 on \`/api/invite/current\`)
- [ ] If invite link doesn't exist, "Skapa delningslänk" knappen ska fungera
- [ ] If invite link exists, det ska visas direkt
- [ ] "Generera ny länk" ska fungera

🤖 Generated with [Claude Code](https://claude.com/claude-code)