### PR TITLE
feat(auth): specific login errors + parent-controlled child password reset

### DIFF
--- a/src/app/api/auth/reset-child-password/route.ts
+++ b/src/app/api/auth/reset-child-password/route.ts
@@ -1,0 +1,66 @@
+import 'server-only';
+import { NextRequest, NextResponse } from 'next/server';
+import { adminAuth, adminDb } from '@/lib/firebase/admin';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  const { idToken, childUid, newPassword } = body as {
+    idToken?: string;
+    childUid?: string;
+    newPassword?: string;
+  };
+
+  if (!idToken || !childUid || !newPassword) {
+    return NextResponse.json(
+      { error: 'idToken, childUid, and newPassword required' },
+      { status: 400 },
+    );
+  }
+
+  if (newPassword.length < 6) {
+    return NextResponse.json(
+      { error: 'Lösenordet måste vara minst 6 tecken.' },
+      { status: 400 },
+    );
+  }
+
+  let decoded;
+  try {
+    decoded = await adminAuth.verifyIdToken(idToken);
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Authorize: caller must be a parent of the target child.
+  // Source of truth is wishlists/{childUid}.parentUids (set on register-child + invite redemption).
+  const wishlistSnap = await adminDb.collection('wishlists').doc(childUid).get();
+  if (!wishlistSnap.exists) {
+    return NextResponse.json({ error: 'Child not found' }, { status: 404 });
+  }
+  const parentUids: string[] = wishlistSnap.data()?.parentUids ?? [];
+  if (!parentUids.includes(decoded.uid)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // Sanity-check: target must actually be a child account
+  const userSnap = await adminDb.collection('users').doc(childUid).get();
+  if (!userSnap.exists || userSnap.data()?.role !== 'child') {
+    return NextResponse.json({ error: 'Target is not a child account' }, { status: 400 });
+  }
+
+  try {
+    await adminAuth.updateUser(childUid, { password: newPassword });
+  } catch (err: unknown) {
+    const code = (err as { code?: string }).code;
+    if (code === 'auth/user-not-found') {
+      return NextResponse.json({ error: 'Child auth account not found' }, { status: 404 });
+    }
+    if (code === 'auth/invalid-password') {
+      return NextResponse.json({ error: 'Lösenordet är ogiltigt.' }, { status: 400 });
+    }
+    console.error('[reset-child-password] updateUser failed:', err);
+    return NextResponse.json({ error: 'Något gick fel. Försök igen.' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -31,7 +31,7 @@ export default function LoginPage() {
         const snap = await getDoc(usernameRef);
 
         if (!snap.exists()) {
-          setError('Användarnamn eller lösenord är felaktigt');
+          setError('Det finns inget barnkonto med det användarnamnet.');
           return;
         }
 
@@ -42,8 +42,24 @@ export default function LoginPage() {
       const idTokenResult = await result.user.getIdTokenResult();
       const role = idTokenResult.claims['role'] as string | undefined;
       router.push(role === 'child' ? '/wishlist' : '/dashboard');
-    } catch {
-      setError('Användarnamn eller lösenord är felaktigt');
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code ?? '';
+      if (
+        code === 'auth/wrong-password' ||
+        code === 'auth/invalid-credential'
+      ) {
+        setError('Fel lösenord. Be en förälder återställa det om det glömts bort.');
+      } else if (code === 'auth/user-not-found') {
+        setError('Det finns inget konto med de uppgifterna.');
+      } else if (code === 'auth/too-many-requests') {
+        setError('För många misslyckade försök. Vänta en stund innan du försöker igen.');
+      } else if (code === 'auth/network-request-failed') {
+        setError('Nätverksfel. Kontrollera anslutningen och försök igen.');
+      } else if (code === 'auth/user-disabled') {
+        setError('Kontot är inaktiverat.');
+      } else {
+        setError('Inloggningen misslyckades. Försök igen.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/app/wishlist/[wishlistId]/settings/page.tsx
+++ b/src/app/wishlist/[wishlistId]/settings/page.tsx
@@ -8,6 +8,149 @@ import { ShareLinkPanel } from '@/components/viewer/ShareLinkPanel';
 import Link from 'next/link';
 import { LightShell, ArrowLeft, Calendar, UserIcon } from '@/components/galaxy';
 
+function ResetChildPasswordSection({ childUid }: { childUid: string }) {
+  const [open, setOpen] = useState(false);
+  const [pw1, setPw1] = useState('');
+  const [pw2, setPw2] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setPw1('');
+    setPw2('');
+    setError(null);
+    setSaved(false);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    if (pw1.length < 6) {
+      setError('Lösenordet måste vara minst 6 tecken.');
+      return;
+    }
+    if (pw1 !== pw2) {
+      setError('Lösenorden matchar inte.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const idToken = await auth.currentUser?.getIdToken();
+      if (!idToken) {
+        setError('Sessionen har gått ut. Logga in igen.');
+        return;
+      }
+      const res = await fetch('/api/auth/reset-child-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idToken, childUid, newPassword: pw1 }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? 'Något gick fel. Försök igen.');
+        return;
+      }
+      setSaved(true);
+      setPw1('');
+      setPw2('');
+      setTimeout(() => setSaved(false), 4000);
+    } catch {
+      setError('Något gick fel. Försök igen.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="light-card p-5">
+      <div className="flex items-center gap-2">
+        <UserIcon size={16} color="var(--color-accent)" />
+        <h2 className="font-display font-bold text-[16px]">Återställ barnets lösenord</h2>
+      </div>
+      <p className="mt-1 text-[12px]" style={{ color: 'var(--color-muted-light)' }}>
+        Sätt ett nytt lösenord om barnet har glömt det. Användarnamnet ändras inte.
+      </p>
+
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="light-cta-outline mt-4"
+        >
+          Sätt nytt lösenord
+        </button>
+      ) : (
+        <form onSubmit={handleSave} className="mt-4 flex flex-col gap-3">
+          <div>
+            <label
+              htmlFor="reset-pw1"
+              className="block mb-1.5 text-[10px] font-bold tracking-caps"
+              style={{ color: 'var(--color-muted-light)' }}
+            >
+              Nytt lösenord
+            </label>
+            <input
+              id="reset-pw1"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={pw1}
+              onChange={(e) => setPw1(e.target.value)}
+              className="light-input"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="reset-pw2"
+              className="block mb-1.5 text-[10px] font-bold tracking-caps"
+              style={{ color: 'var(--color-muted-light)' }}
+            >
+              Bekräfta nytt lösenord
+            </label>
+            <input
+              id="reset-pw2"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={pw2}
+              onChange={(e) => setPw2(e.target.value)}
+              className="light-input"
+            />
+          </div>
+          {error && (
+            <p role="alert" className="text-[13px]" style={{ color: 'var(--color-destructive)' }}>
+              {error}
+            </p>
+          )}
+          {saved && (
+            <p role="status" className="text-[13px] font-semibold" style={{ color: '#059669' }}>
+              Lösenordet är uppdaterat. Berätta det nya för barnet.
+            </p>
+          )}
+          <div className="flex gap-3 flex-wrap mt-1">
+            <button type="submit" disabled={saving} className="light-cta">
+              {saving ? 'Sparar…' : 'Spara nytt lösenord'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                reset();
+              }}
+              className="px-4 py-3 text-[13px] font-semibold"
+              style={{ color: 'var(--color-muted-light)' }}
+            >
+              Avbryt
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
 function OccasionSection({
   wishlistId,
   initialOccasion,
@@ -422,7 +565,10 @@ export default function WishlistSettingsPage({
         <ShareLinkPanel wishlistId={wishlistId} viewers={viewers} />
         <CoParentInviteSection wishlistId={wishlistId} initialToken={initialParentToken} />
         {accessType === 'parent' && (
-          <DangerZone wishlistId={wishlistId} childUid={wishlistId} />
+          <>
+            <ResetChildPasswordSection childUid={wishlistId} />
+            <DangerZone wishlistId={wishlistId} childUid={wishlistId} />
+          </>
         )}
       </div>
     </LightShell>


### PR DESCRIPTION
## Summary

- Login now reports **why** sign-in fails (unknown username vs. wrong password vs. rate limit vs. network) instead of one generic message — needed to diagnose why a child can't log in
- Adds parent-only "Sätt nytt lösenord"-flow so parents can recover a child's forgotten password without Firebase Console access

## Why

We had a child who couldn't log in even with the right password, and the existing UI swallowed every error as "Användarnamn eller lösenord är felaktigt" — impossible to tell whether the username doc was missing, the password was wrong, or the request was rate-limited. Same incident also surfaced that there's no in-app way for a parent to reset a child's password.

## Changes

- **`src/app/login/page.tsx`** — distinguishes `auth/wrong-password`, `auth/invalid-credential`, `auth/user-not-found`, `auth/too-many-requests`, `auth/network-request-failed`, `auth/user-disabled`, plus the existing "no usernames doc"-case
- **`src/app/api/auth/reset-child-password/route.ts`** (new) — `POST` endpoint, verifies caller via `verifyIdToken`, authorizes against `wishlists/{childUid}.parentUids` (same source of truth as DELETE-account), sanity-checks target is a child account, calls `adminAuth.updateUser({ password })`. Min length 6, mirrors child-account creation
- **`src/app/wishlist/[wishlistId]/settings/page.tsx`** — new `ResetChildPasswordSection` shown only to parents (`accessType === 'parent'`), placed above the existing DangerZone. Two password fields with confirm + 6-char min validation, success message tells parent to share new password with the child

## Test plan

- [ ] Login with non-existent username → "Det finns inget barnkonto med det användarnamnet"
- [ ] Login with valid username + wrong password → "Fel lösenord. Be en förälder återställa det…"
- [ ] As parent, open `/wishlist/{childUid}/settings` → "Återställ barnets lösenord"-card visible
- [ ] Click "Sätt nytt lösenord", enter password < 6 chars → blocked client-side
- [ ] Mismatched confirm → blocked client-side
- [ ] Valid new password → success message; child can now log in with the new password
- [ ] Non-parent caller (viewer/child) hitting the endpoint directly → 403
- [ ] Endpoint with missing/invalid idToken → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)