### PR TITLE
fix(ui): overflow-x: clip + FAB above iOS Safari toolbar + URL input width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,15 +81,16 @@ html, body {
   font-feature-settings: 'ss01';
   /* Belt-and-braces: prevent any decorative element (aurora orbs, glow halos
      positioned outside the viewport, accidentally-wide content) from creating
-     horizontal scroll. */
+     horizontal scroll. iOS Safari historically ignores overflow-x:hidden when
+     there's a position:fixed descendant — overflow-x:clip is more reliable. */
   max-width: 100vw;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 body {
   min-height: 100dvh;
-  /* Use dynamic viewport so iOS Safari toolbars don't push content. */
   width: 100%;
+  position: relative;
 }
 
 /* Long URLs and copy with no break opportunities should wrap rather than push

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -175,9 +175,10 @@ function Step3({ wishlistId }: { wishlistId: string }) {
           <input
             type="text"
             readOnly
+            size={1}
             value={inviteUrl ?? ''}
             aria-label="Delningslänk"
-            className="flex-1 min-w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
+            className="flex-1 min-w-0 w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
             style={{ color: 'var(--color-ink-light)' }}
           />
           <button

--- a/src/app/wishlist/[wishlistId]/settings/page.tsx
+++ b/src/app/wishlist/[wishlistId]/settings/page.tsx
@@ -333,9 +333,10 @@ function CoParentInviteSection({
           <input
             type="text"
             readOnly
+            size={1}
             value={inviteUrl ?? ''}
             aria-label="Co-förälderlänk"
-            className="flex-1 min-w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
+            className="flex-1 min-w-0 w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
             style={{ color: 'var(--color-ink-light)' }}
           />
           <button

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -222,7 +222,10 @@ export default function WishlistPage() {
           className="anim-fab tap-feedback fixed z-20 flex items-center gap-2 font-display font-bold text-[14px]"
           style={{
             right: 'max(18px, env(safe-area-inset-right))',
-            bottom: 'calc(20px + env(safe-area-inset-bottom, 0px))',
+            /* iOS Safari URL/tab bar shrinks `100dvh` but `env(safe-area-inset-bottom)`
+               returns 0 while the bar is visible — so a bare `env()` puts the FAB
+               *behind* the toolbar. We bump the offset enough to clear it. */
+            bottom: 'max(28px, calc(env(safe-area-inset-bottom, 0px) + 24px))',
             padding: '14px 22px',
             minHeight: 52,
             borderRadius: 9999,

--- a/src/components/viewer/ShareLinkPanel.tsx
+++ b/src/components/viewer/ShareLinkPanel.tsx
@@ -134,9 +134,10 @@ export function ShareLinkPanel({ wishlistId, viewers }: ShareLinkPanelProps) {
             <input
               type="text"
               readOnly
+              size={1}
               value={inviteUrl ?? ''}
               aria-label="Delningslänk"
-              className="flex-1 min-w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
+              className="flex-1 min-w-0 w-0 bg-transparent border-0 outline-none text-[12px] font-mono"
               style={{ color: 'var(--color-ink-light)' }}
             />
             <button


### PR DESCRIPTION
## Summary

Three follow-up fixes after on-device testing of #33. Despite the previous overflow clamp, iOS Safari was still letting horizontal scroll through (header icons clipped), the wishlist FAB was hidden behind the Safari toolbar, and the share-link inputs were silently expanding their parent — all of which produce a non-app feel on mobile.

## Why each change

### 1. `overflow-x: clip` instead of `hidden` (`src/app/globals.css`)
iOS Safari has a long-standing bug where `overflow-x: hidden` on `<html>/<body>` is ignored when there's a `position: fixed` descendant — exactly our wishlist FAB. `overflow-x: clip` is respected even in that case.

### 2. FAB bottom offset (`src/app/wishlist/page.tsx`)
`env(safe-area-inset-bottom)` returns **0** while the Safari URL/tab bar is visible, so a bare `env()` offset puts the FAB *underneath* the toolbar. The bar is ~50px tall on iPhone — bumped the floor to `max(28px, env() + 24px)` so the FAB clears the bar even with chrome shown, and still respects the home-indicator when the bar is hidden.

### 3. URL input width (`ShareLinkPanel`, settings, onboarding)
`<input type="text" value={veryLongUrl} />` on iOS Safari can expand its parent past `min-w-0` because `<input>` has its own intrinsic min-content based on `size`. Added `size={1}` + explicit `w-0` so the inputs collapse to whatever space their flex parent gives them.

## Test plan

- [ ] On iPhone Safari, header icons (Cog, LogOut) on `/wishlist` are fully visible
- [ ] Long invite URL on `/wishlist/[id]/settings` doesn't push the share-link card past viewport
- [ ] Önska FAB sits clearly above Safari toolbar (not hidden behind it)
- [ ] Önska FAB still respects home-indicator when toolbar is collapsed
- [ ] No horizontal scroll on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)