### PR TITLE
fix(ui): cross-browser horizontal scroll + FAB above Chrome iOS toolbar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,10 +79,10 @@ html, body {
   color: var(--color-ink);
   font-family: var(--font-nunito), system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-feature-settings: 'ss01';
-  /* Belt-and-braces: prevent any decorative element (aurora orbs, glow halos
-     positioned outside the viewport, accidentally-wide content) from creating
-     horizontal scroll. iOS Safari historically ignores overflow-x:hidden when
-     there's a position:fixed descendant — overflow-x:clip is more reliable. */
+  /* Belt-and-braces against horizontal scroll. iOS Safari ignores
+     overflow-x: hidden when there's a position:fixed descendant; clip is
+     respected. Chrome iOS still leaks unless we also clamp width. */
+  width: 100%;
   max-width: 100vw;
   overflow-x: clip;
 }
@@ -91,6 +91,22 @@ body {
   min-height: 100dvh;
   width: 100%;
   position: relative;
+}
+
+/* Native form controls (date pickers, number spinners) on iOS Safari and
+   Chrome iOS render with intrinsic widths bigger than their flex parent
+   when given a long value or `size` attribute. Force them to obey their
+   container instead. */
+input, select, textarea {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+/* dnd-kit applies inline transforms via style; ensure our list items
+   never report a layout width larger than their parent regardless of
+   transform during drag. */
+[data-rfd-draggable-id], li.night-card, li.light-card {
+  max-width: 100%;
 }
 
 /* Long URLs and copy with no break opportunities should wrap rather than push

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -213,7 +213,12 @@ export default function WishlistPage() {
         )}
       </div>
 
-      {/* FAB */}
+      {/* FAB — fixed but offset using the dvh-svh delta to clear the iOS
+          browser toolbar. When the URL/tab bar is visible 100svh < 100dvh,
+          and that delta equals the toolbar height (env(safe-area-inset-bottom)
+          returns 0 in that state in both Safari and Chrome iOS, so we can't
+          use it). When the toolbar is collapsed the delta is 0, so we floor
+          to a fixed safe-area offset. */}
       {!showAddForm && !isEmpty && (
         <button
           type="button"
@@ -222,10 +227,8 @@ export default function WishlistPage() {
           className="anim-fab tap-feedback fixed z-20 flex items-center gap-2 font-display font-bold text-[14px]"
           style={{
             right: 'max(18px, env(safe-area-inset-right))',
-            /* iOS Safari URL/tab bar shrinks `100dvh` but `env(safe-area-inset-bottom)`
-               returns 0 while the bar is visible — so a bare `env()` puts the FAB
-               *behind* the toolbar. We bump the offset enough to clear it. */
-            bottom: 'max(28px, calc(env(safe-area-inset-bottom, 0px) + 24px))',
+            bottom:
+              'max(20px, calc(100dvh - 100svh + 20px), calc(env(safe-area-inset-bottom, 0px) + 20px))',
             padding: '14px 22px',
             minHeight: 52,
             borderRadius: 9999,


### PR DESCRIPTION
## Summary

Standalone follow-up to the mobile-polish PR. Two issues observed on iPhone 15 Pro Chrome:

1. Horizontal scroll still leaked — header icons clipped, glow stripe on wishlist cards visible past the left edge
2. Önska FAB hung underneath Chrome iOS's bottom tab bar (Safari was OK; Chrome iOS is harder to clear)

Plus a third issue from settings: the date input expanded its parent card past viewport.

## Why each change

### `globals.css` — defensive width clamps
- `width: 100%` on html/body alongside `max-width: 100vw` + `overflow-x: clip`. iOS Safari respects `clip` but Chrome iOS still leaks unless width is also clamped.
- `input, select, textarea { max-width: 100%; box-sizing: border-box }` — native form controls (especially `<input type="date">` and number spinners) ignore flex-parent constraints and report intrinsic widths from their `value`/`size`. This forces them to obey their container.
- Defensive `max-width: 100%` on `.night-card` / `.light-card` list items — covers the brief moment during a dnd-kit drag where the transformed item could report a wider box than its parent.

### Wishlist FAB — `100dvh − 100svh` toolbar-height trick
`env(safe-area-inset-bottom)` returns **0** while the iOS browser URL/tab bar is visible in both Safari and Chrome — useless as a "clear the bar" offset.

The dynamic-viewport delta (`100dvh − 100svh`) **equals** the toolbar height when the bar is visible and **0** when it's collapsed. Floor with `max(20px, …, env() + 20px)` so the FAB always clears the bar, respects the home indicator when the bar is collapsed, and falls back to a safe minimum on browsers where dvh/svh aren't supported.

## Test plan

- [ ] Chrome iOS on iPhone — no horizontal scroll on `/wishlist` (header icons fully visible)
- [ ] Chrome iOS — Önska FAB sits clearly above the bottom tab bar, never hidden
- [ ] Safari iOS — same behavior, FAB respects URL bar AND home indicator when scrolled
- [ ] Date input on `/wishlist/[id]/settings` doesn't expand its card past viewport
- [ ] Drag-reorder on wishlist still works without ghost wobble

🤖 Generated with [Claude Code](https://claude.com/claude-code)