### PR TITLE
feat(ux): optimistic reorder, smoother add-item flow, forgiving URL input

### DIFF
--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -20,7 +20,7 @@ import {
   closestCenter,
 } from '@dnd-kit/core';
 import type { DragEndEvent } from '@dnd-kit/core';
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import {
   NightShell,
   BrandHeader,
@@ -100,11 +100,20 @@ export default function WishlistPage() {
     if (oldIndex === -1 || newIndex === -1) return;
 
     const remaining = items.filter((i) => i.id !== active.id);
-    const insertAt = newIndex > oldIndex ? newIndex : newIndex;
-    const prevPos = remaining[insertAt - 1]?.position ?? null;
-    const nextPos = remaining[insertAt]?.position ?? null;
+    const prevPos = remaining[newIndex - 1]?.position ?? null;
+    const nextPos = remaining[newIndex]?.position ?? null;
 
-    await updateItemPosition(wishlistId, active.id as string, prevPos, nextPos);
+    // Optimistic reorder so the card stays where it was dropped instead of
+    // snapping back while the write is in flight; the Firestore subscription
+    // remains the source of truth once the snapshot arrives.
+    const previousItems = items;
+    setItems(arrayMove(items, oldIndex, newIndex));
+
+    try {
+      await updateItemPosition(wishlistId, active.id as string, prevPos, nextPos);
+    } catch {
+      setItems(previousItems);
+    }
   }
 
   if (loading || dataLoading) return <LoadingSkeleton />;

--- a/src/components/viewer/ParentAddItemForm.tsx
+++ b/src/components/viewer/ParentAddItemForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { auth } from '@/lib/firebase/client';
+import { normalizeUrl, isSafeUrl } from '@/lib/url';
 
 interface ParentAddItemFormProps {
   wishlistId: string;
@@ -23,6 +24,11 @@ export function ParentAddItemForm({ wishlistId, onClose, onError }: ParentAddIte
       setTitleError('Titel krävs');
       return;
     }
+    const normalizedProductUrl = normalizeUrl(productUrl);
+    if (normalizedProductUrl && !isSafeUrl(normalizedProductUrl)) {
+      onError('Länken måste vara en webbadress (https://…)');
+      return;
+    }
     setSaving(true);
     try {
       const idToken = await auth.currentUser?.getIdToken();
@@ -34,7 +40,7 @@ export function ParentAddItemForm({ wishlistId, onClose, onError }: ParentAddIte
           idToken,
           wishlistId,
           title: title.trim(),
-          ...(productUrl.trim() ? { productUrl: productUrl.trim() } : {}),
+          ...(normalizedProductUrl ? { productUrl: normalizedProductUrl } : {}),
           ...(note.trim() ? { note: note.trim() } : {}),
           ...(price !== '' ? { price: Number(price) } : {}),
         }),
@@ -53,7 +59,7 @@ export function ParentAddItemForm({ wishlistId, onClose, onError }: ParentAddIte
   }
 
   return (
-    <form onSubmit={handleSubmit} className="light-card p-5 flex flex-col gap-3">
+    <form onSubmit={handleSubmit} noValidate className="light-card p-5 flex flex-col gap-3">
       <div>
         <label
           htmlFor="parent-item-title"
@@ -66,6 +72,7 @@ export function ParentAddItemForm({ wishlistId, onClose, onError }: ParentAddIte
           id="parent-item-title"
           type="text"
           required
+          autoFocus
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           className="light-input"
@@ -106,6 +113,7 @@ export function ParentAddItemForm({ wishlistId, onClose, onError }: ParentAddIte
           type="url"
           value={productUrl}
           onChange={(e) => setProductUrl(e.target.value)}
+          onBlur={(e) => setProductUrl(normalizeUrl(e.target.value))}
           className="light-input font-mono text-[12px]"
         />
       </div>

--- a/src/components/viewer/ViewerWishItemCard.tsx
+++ b/src/components/viewer/ViewerWishItemCard.tsx
@@ -4,11 +4,8 @@ import { PurchasedBadge } from '@/components/viewer/PurchasedBadge';
 import { ViewerNoteField } from '@/components/viewer/ViewerNoteField';
 import { OtherViewerNotes } from '@/components/viewer/OtherViewerNotes';
 import { Check } from '@/components/galaxy';
+import { isSafeUrl } from '@/lib/url';
 import type { WishItemDoc, PurchaseStatusDoc } from '@/types/firestore';
-
-function isSafeUrl(url: string): boolean {
-  return url.startsWith('https://') || url.startsWith('http://');
-}
 
 interface ViewerWishItemCardProps {
   item: WishItemDoc;

--- a/src/components/wishlist/AddItemForm.tsx
+++ b/src/components/wishlist/AddItemForm.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { addWishItem } from '@/lib/firebase/wishlist';
+import { normalizeUrl, isSafeUrl } from '@/lib/url';
 import { Sparkle } from '@/components/galaxy';
 
 interface AddItemFormProps {
@@ -25,6 +26,11 @@ export function AddItemForm({ wishlistId, lastPosition, onClose }: AddItemFormPr
   const [saving, setSaving] = useState(false);
   const [titleError, setTitleError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -34,14 +40,24 @@ export function AddItemForm({ wishlistId, lastPosition, onClose }: AddItemFormPr
       setTitleError('Titel krävs');
       return;
     }
+    const normalizedProductUrl = normalizeUrl(productUrl);
+    const normalizedImageUrl = normalizeUrl(imageUrl);
+    if (normalizedProductUrl && !isSafeUrl(normalizedProductUrl)) {
+      setSaveError('Länken måste vara en webbadress (https://…)');
+      return;
+    }
+    if (normalizedImageUrl && !isSafeUrl(normalizedImageUrl)) {
+      setSaveError('Bildlänken måste vara en webbadress (https://…)');
+      return;
+    }
     setSaving(true);
     try {
       await addWishItem(
         wishlistId,
         {
           title: title.trim(),
-          ...(productUrl.trim() ? { productUrl: productUrl.trim() } : {}),
-          ...(imageUrl.trim() ? { imageUrl: imageUrl.trim() } : {}),
+          ...(normalizedProductUrl ? { productUrl: normalizedProductUrl } : {}),
+          ...(normalizedImageUrl ? { imageUrl: normalizedImageUrl } : {}),
           ...(note.trim() ? { note: note.trim() } : {}),
           ...(price !== '' ? { price: Number(price) } : {}),
         },
@@ -88,8 +104,10 @@ export function AddItemForm({ wishlistId, lastPosition, onClose }: AddItemFormPr
           type={isPrice ? 'number' : isUrl ? 'url' : 'text'}
           min={isPrice ? '0' : undefined}
           required={id === 'title'}
+          autoFocus={id === 'title'}
           value={value as string | number}
           onChange={(e) => setValue(e.target.value)}
+          onBlur={isUrl ? (e) => setValue(normalizeUrl(e.target.value)) : undefined}
           placeholder={
             id === 'imageUrl'
               ? 'Klistra in bildlänk'
@@ -111,7 +129,9 @@ export function AddItemForm({ wishlistId, lastPosition, onClose }: AddItemFormPr
 
   return (
     <form
+      ref={formRef}
       onSubmit={handleSubmit}
+      noValidate
       className="night-card flex flex-col gap-4 p-5"
     >
       {FIELDS.map((f) => renderField(f.id, f.label, f.accent))}
@@ -142,7 +162,7 @@ export function AddItemForm({ wishlistId, lastPosition, onClose }: AddItemFormPr
 
       <div className="flex gap-3 flex-wrap mt-1">
         <button type="submit" disabled={saving} className="neon-cta">
-          <Sparkle size={14} color="#fff" /> Tänd stjärnan
+          <Sparkle size={14} color="#fff" /> {saving ? 'Sparar…' : 'Tänd stjärnan'}
         </button>
         <button type="button" onClick={onClose} className="neon-cta-outline">
           Avbryt

--- a/src/components/wishlist/WishItemCard.tsx
+++ b/src/components/wishlist/WishItemCard.tsx
@@ -3,14 +3,11 @@ import { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { updateWishItem, deleteWishItem } from '@/lib/firebase/wishlist';
+import { normalizeUrl, isSafeUrl } from '@/lib/url';
 import type { WishItemDoc } from '@/types/firestore';
 import { Star, Heart, GripDots, Pencil, Trash } from '@/components/galaxy';
 
 const ACCENTS = ['#7DE3FF', '#FF7AB8', '#FFD36E', '#B28BFF', '#85F2CA'];
-
-function isSafeUrl(url: string): boolean {
-  return url.startsWith('https://') || url.startsWith('http://');
-}
 
 interface WishItemCardProps {
   item: WishItemDoc;
@@ -77,16 +74,15 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
     setEditSaving(true);
     setEditSaveError(null);
     try {
-      const SAFE_URL_PREFIXES = ['https://', 'http://'];
-      const trimmedProductUrl = editProductUrl.trim() || undefined;
-      const trimmedImageUrl = editImageUrl.trim() || undefined;
-      if (trimmedProductUrl && !SAFE_URL_PREFIXES.some(p => trimmedProductUrl.startsWith(p))) {
-        setEditSaveError('Länken måste börja med https:// eller http://');
+      const trimmedProductUrl = normalizeUrl(editProductUrl) || undefined;
+      const trimmedImageUrl = normalizeUrl(editImageUrl) || undefined;
+      if (trimmedProductUrl && !isSafeUrl(trimmedProductUrl)) {
+        setEditSaveError('Länken måste vara en webbadress (https://…)');
         setEditSaving(false);
         return;
       }
-      if (trimmedImageUrl && !SAFE_URL_PREFIXES.some(p => trimmedImageUrl.startsWith(p))) {
-        setEditSaveError('Bildlänken måste börja med https:// eller http://');
+      if (trimmedImageUrl && !isSafeUrl(trimmedImageUrl)) {
+        setEditSaveError('Bildlänken måste vara en webbadress (https://…)');
         setEditSaving(false);
         return;
       }
@@ -144,7 +140,7 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
       />
 
       {editMode ? (
-        <form onSubmit={handleSave} className="flex flex-col gap-3 p-4 pl-5">
+        <form onSubmit={handleSave} noValidate className="flex flex-col gap-3 p-4 pl-5">
           <div>
             <label
               htmlFor={`title-${item.id}`}
@@ -157,6 +153,7 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
               id={`title-${item.id}`}
               type="text"
               required
+              autoFocus
               value={editTitle}
               onChange={(e) => setEditTitle(e.target.value)}
               className="night-input"
@@ -197,6 +194,7 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
               type="url"
               value={editProductUrl}
               onChange={(e) => setEditProductUrl(e.target.value)}
+              onBlur={(e) => setEditProductUrl(normalizeUrl(e.target.value))}
               className="night-input font-mono text-[12px]"
             />
           </div>
@@ -213,6 +211,7 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
               type="url"
               value={editImageUrl}
               onChange={(e) => setEditImageUrl(e.target.value)}
+              onBlur={(e) => setEditImageUrl(normalizeUrl(e.target.value))}
               className="night-input font-mono text-[12px]"
             />
           </div>
@@ -240,7 +239,7 @@ export function WishItemCard({ item, wishlistId, totalFavorites, index = 0 }: Wi
           )}
           <div className="flex gap-3 flex-wrap items-center mt-1">
             <button type="submit" disabled={editSaving} className="neon-cta">
-              Spara
+              {editSaving ? 'Sparar…' : 'Spara'}
             </button>
             <button type="button" onClick={handleCancelEdit} className="neon-cta-outline">
               Avbryt

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,16 @@
+export function isSafeUrl(url: string): boolean {
+  return url.startsWith('https://') || url.startsWith('http://');
+}
+
+/**
+ * Normalize a user-entered URL: trims whitespace and prepends https://
+ * when no scheme is present (e.g. "www.lego.com" → "https://www.lego.com").
+ * Values with an explicit scheme are returned as-is so unsafe schemes
+ * can still be rejected by validation.
+ */
+export function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}

--- a/tests/lib/url.test.ts
+++ b/tests/lib/url.test.ts
@@ -1,0 +1,39 @@
+import { normalizeUrl, isSafeUrl } from '@/lib/url';
+
+describe('normalizeUrl', () => {
+  it('returns empty string for empty or whitespace input', () => {
+    expect(normalizeUrl('')).toBe('');
+    expect(normalizeUrl('   ')).toBe('');
+  });
+
+  it('prepends https:// when no scheme is present', () => {
+    expect(normalizeUrl('www.lego.com/produkt')).toBe('https://www.lego.com/produkt');
+    expect(normalizeUrl('lego.com')).toBe('https://lego.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeUrl('  www.lego.com  ')).toBe('https://www.lego.com');
+  });
+
+  it('keeps existing http/https schemes unchanged', () => {
+    expect(normalizeUrl('https://lego.com')).toBe('https://lego.com');
+    expect(normalizeUrl('http://lego.com')).toBe('http://lego.com');
+  });
+
+  it('leaves other schemes as-is so validation can reject them', () => {
+    expect(normalizeUrl('javascript:alert(1)')).toBe('javascript:alert(1)');
+    expect(normalizeUrl('ftp://example.com')).toBe('ftp://example.com');
+  });
+});
+
+describe('isSafeUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeUrl('https://lego.com')).toBe(true);
+    expect(isSafeUrl('http://lego.com')).toBe(true);
+  });
+
+  it('rejects other schemes', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeUrl('ftp://example.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
- Reorder wish items optimistically on drag end so the card stays where
  it was dropped instead of snapping back until Firestore confirms;
  revert to the previous order if the write fails.
- Scroll the add-item form into view and autofocus the title field when
  it opens (it renders below the list, so it could open off-screen), and
  show "Sparar…" on submit buttons while saving.
- Normalize pasted links: prepend https:// when the scheme is missing
  (on blur and on save) in the add/edit/parent forms, with a shared
  helper in src/lib/url.ts replacing duplicated isSafeUrl copies.
  Forms use noValidate so validation errors are shown in Swedish
  instead of native browser messages.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JRjA9JsbpUX69FVbvdYxmv