### PR TITLE
feat(pwa): install prompt on mobile + smoother multi-child parent flow

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -163,6 +163,22 @@ export default function DashboardPage() {
 
   const userInitial = (user.email ?? '?').slice(0, 1).toUpperCase();
 
+  // Upcoming occasions first (soonest on top), then the rest by child name,
+  // so the list a parent needs to act on is always at the top.
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const sortKey = (wl: WishlistDoc) => {
+    const date = wl.occasion?.date;
+    return date && date >= todayIso ? date : '9999-99-99';
+  };
+  const sortedParentWishlists = [...parentWishlists].sort((a, b) => {
+    const dateCmp = sortKey(a).localeCompare(sortKey(b));
+    if (dateCmp !== 0) return dateCmp;
+    return (childNames.get(a.childUid) ?? '').localeCompare(
+      childNames.get(b.childUid) ?? '',
+      'sv'
+    );
+  });
+
   return (
     <LightShell>
       {/* Header */}
@@ -226,7 +242,7 @@ export default function DashboardPage() {
             </button>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {parentWishlists.map((wl) => (
+              {sortedParentWishlists.map((wl) => (
                 <ParentWishlistDashboardCard
                   key={wl.id}
                   wishlist={wl}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Fraunces, Nunito } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
+import { InstallPrompt } from "@/components/InstallPrompt";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -63,6 +64,7 @@ export default function RootLayout({
           }}
         />
         <AuthProvider>{children}</AuthProvider>
+        <InstallPrompt />
       </body>
     </html>
   );

--- a/src/app/viewer/[wishlistId]/page.tsx
+++ b/src/app/viewer/[wishlistId]/page.tsx
@@ -1,15 +1,15 @@
 'use client';
-import { use, useEffect, useState, useCallback } from 'react';
+import { use, useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { doc, getDoc } from 'firebase/firestore';
 import { db, auth } from '@/lib/firebase/client';
 import { useAuth } from '@/components/AuthProvider';
 import { subscribeToItems } from '@/lib/firebase/wishlist';
-import { subscribeToPurchaseStatus } from '@/lib/firebase/viewer';
+import { subscribeToPurchaseStatus, subscribeToParentWishlists } from '@/lib/firebase/viewer';
 import { ViewerWishItemCard } from '@/components/viewer/ViewerWishItemCard';
 import { ParentAddItemForm } from '@/components/viewer/ParentAddItemForm';
 import { LoadingSkeleton } from '@/components/wishlist/LoadingSkeleton';
-import type { WishItemDoc, PurchaseStatusDoc } from '@/types/firestore';
+import type { WishItemDoc, PurchaseStatusDoc, WishlistDoc } from '@/types/firestore';
 import Link from 'next/link';
 import { LightShell, ArrowLeft, Cog, Plus, Pencil, Heart, Calendar } from '@/components/galaxy';
 
@@ -29,21 +29,43 @@ export default function ViewerWishlistPage({
   const [error, setError] = useState<string | null>(null);
 
   const [wishlistTitle, setWishlistTitle] = useState<string>('');
+  const [childUid, setChildUid] = useState<string>('');
   const [isParent, setIsParent] = useState(false);
+  const [siblingLists, setSiblingLists] = useState<WishlistDoc[]>([]);
+  const [childNames, setChildNames] = useState<Map<string, string>>(new Map());
   const [occasion, setOccasion] = useState<{ name: string; date: string } | null>(null);
   const [showAddItem, setShowAddItem] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
   const [addItemError, setAddItemError] = useState<string | null>(null);
+  const fetchedNamesRef = useRef(new Set<string>());
+  const fetchedChildNamesRef = useRef(new Set<string>());
+
+  // Reset per-list state when switching between children so the previous
+  // child's items don't flash while the new subscriptions warm up.
+  const [prevWishlistId, setPrevWishlistId] = useState(wishlistId);
+  if (prevWishlistId !== wishlistId) {
+    setPrevWishlistId(wishlistId);
+    setItems([]);
+    setStatuses({});
+    setDataLoading(true);
+    setShowAddItem(false);
+    setIsRenaming(false);
+    setRenameError(null);
+    setAddItemError(null);
+  }
 
   useEffect(() => {
     if (!loading && !user) router.push('/login');
     if (!loading && user && role === 'child') router.push('/wishlist');
   }, [loading, user, role, router]);
 
+  // Ref-based dedupe keeps this callback stable — a state-based check would
+  // recreate it on every name fetch and tear down the Firestore subscriptions.
   const fetchDisplayName = useCallback(async (uid: string) => {
-    if (displayNames.has(uid)) return;
+    if (fetchedNamesRef.current.has(uid)) return;
+    fetchedNamesRef.current.add(uid);
     try {
       const snap = await getDoc(doc(db, 'users', uid));
       if (snap.exists()) {
@@ -54,7 +76,22 @@ export default function ViewerWishlistPage({
     } catch {
       // silent
     }
-  }, [displayNames]);
+  }, []);
+
+  const fetchChildName = useCallback(async (uid: string) => {
+    if (fetchedChildNamesRef.current.has(uid)) return;
+    fetchedChildNamesRef.current.add(uid);
+    try {
+      const snap = await getDoc(doc(db, 'users', uid));
+      if (snap.exists()) {
+        const data = snap.data();
+        const name: string = data.displayName ?? data.username ?? data.email ?? uid;
+        setChildNames((prev) => new Map(prev).set(uid, name));
+      }
+    } catch {
+      // silent
+    }
+  }, []);
 
   useEffect(() => {
     if (loading || !user) return;
@@ -67,6 +104,8 @@ export default function ViewerWishlistPage({
         const parentUids: string[] = wlData.parentUids ?? [];
         setIsParent(parentUids.includes(user.uid));
         setOccasion(wlData.occasion ?? null);
+        setChildUid(wlData.childUid ?? '');
+        fetchChildName(wlData.childUid);
       }
     }).catch(() => {
       // silent
@@ -89,7 +128,18 @@ export default function ViewerWishlistPage({
       unsubItems();
       unsubStatus();
     };
-  }, [loading, user, wishlistId, fetchDisplayName]);
+  }, [loading, user, wishlistId, fetchDisplayName, fetchChildName]);
+
+  // Quick switcher between the parent's children (shown when there is
+  // more than one list the user has parent access to).
+  useEffect(() => {
+    if (loading || !user) return;
+    const unsub = subscribeToParentWishlists(user.uid, (lists) => {
+      setSiblingLists(lists);
+      lists.forEach((wl) => fetchChildName(wl.childUid));
+    });
+    return unsub;
+  }, [loading, user, fetchChildName]);
 
   async function handleTogglePurchased(
     itemId: string,
@@ -198,6 +248,13 @@ export default function ViewerWishlistPage({
   const favoriteItems = items.filter((i) => i.isFavorite);
   const otherItems = items.filter((i) => !i.isFavorite);
 
+  const childName = childUid ? childNames.get(childUid) ?? '' : '';
+  const fallbackTitle = childName ? `${childName}s önskelista` : 'Önskelista';
+  const showSwitcher = isParent && siblingLists.length > 1;
+  const switcherLists = [...siblingLists].sort((a, b) =>
+    (childNames.get(a.childUid) ?? '').localeCompare(childNames.get(b.childUid) ?? '', 'sv')
+  );
+
   function renderCard(item: WishItemDoc) {
     const statusDoc = statuses[item.id];
     return (
@@ -259,10 +316,50 @@ export default function ViewerWishlistPage({
         </Link>
       </header>
 
+      {/* Child switcher — jump straight between siblings' lists */}
+      {showSwitcher && (
+        <nav
+          aria-label="Byt barn"
+          className="app-page pb-3 flex gap-2 overflow-x-auto"
+          style={{ background: '#fff' }}
+        >
+          {switcherLists.map((wl) => {
+            const active = wl.id === wishlistId;
+            return (
+              <Link
+                key={wl.id}
+                href={`/viewer/${wl.id}`}
+                aria-current={active ? 'page' : undefined}
+                className="shrink-0 rounded-full px-3.5 py-1.5 text-[13px] font-bold"
+                style={
+                  active
+                    ? { background: 'var(--color-accent)', color: '#fff' }
+                    : {
+                        background: 'var(--color-bg-light)',
+                        color: 'var(--color-muted-light)',
+                        border: '1px solid var(--color-border-light)',
+                      }
+                }
+              >
+                {childNames.get(wl.childUid) ?? '…'}
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+
       <div
         className="app-page pb-4"
         style={{ background: '#fff', borderBottom: '1px solid var(--color-border-light)' }}
       >
+        {childName && !!wishlistTitle && (
+          <p
+            className="text-[11px] font-bold tracking-caps mb-1"
+            style={{ color: 'var(--color-muted-light)' }}
+          >
+            {childName}
+          </p>
+        )}
         {isParent && isRenaming ? (
           <input
             type="text"
@@ -288,7 +385,7 @@ export default function ViewerWishlistPage({
             style={{ color: 'var(--color-ink-light)', cursor: isParent ? 'pointer' : 'default' }}
             aria-label={isParent ? 'Klicka för att byta namn' : undefined}
           >
-            {wishlistTitle || 'Namnlös önskelista'}
+            {wishlistTitle || fallbackTitle}
             {isParent && <Pencil size={14} color="var(--color-muted-light)" />}
           </button>
         )}

--- a/src/app/wishlist/[wishlistId]/settings/page.tsx
+++ b/src/app/wishlist/[wishlistId]/settings/page.tsx
@@ -477,6 +477,7 @@ export default function WishlistSettingsPage({
   const [accessType, setAccessType] = useState<'child' | 'parent' | null>(null);
   const [initialParentToken, setInitialParentToken] = useState<string | null>(null);
   const [initialOccasion, setInitialOccasion] = useState<{ name: string; date: string } | null>(null);
+  const [childName, setChildName] = useState<string>('');
 
   useEffect(() => {
     if (!loading && !user) router.push('/login');
@@ -506,6 +507,14 @@ export default function WishlistSettingsPage({
         setAccessType(callerIsOwner ? 'child' : 'parent');
         setInitialParentToken(data.currentParentInviteToken ?? null);
         setInitialOccasion(data.occasion ?? null);
+
+        try {
+          const childSnap = await getDoc(doc(db, 'users', data.childUid));
+          const childData = childSnap.data();
+          setChildName(childData?.displayName ?? childData?.username ?? '');
+        } catch {
+          // silent — header just omits the name
+        }
 
         const viewerUids: string[] = data.viewerUids ?? [];
         const resolved = await Promise.all(
@@ -558,6 +567,11 @@ export default function WishlistSettingsPage({
         </Link>
         <div>
           <h1 className="font-display font-bold text-[20px]">Inställningar</h1>
+          {childName && (
+            <p className="text-[12px]" style={{ color: 'var(--color-muted-light)' }}>
+              {childName}s önskelista
+            </p>
+          )}
         </div>
       </header>
 

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,164 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+// Chrome/Edge on Android fire this non-standard event when the app is
+// installable; we stash it and trigger the native prompt from our banner.
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+const DISMISS_KEY = 'onskestjarnan-install-dismissed';
+const SNOOZE_DAYS = 14;
+
+function isSnoozed(): boolean {
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    if (raw === 'installed') return true;
+    const dismissedAt = Number(raw);
+    return Date.now() - dismissedAt < SNOOZE_DAYS * 86_400_000;
+  } catch {
+    return false;
+  }
+}
+
+function isStandalone(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    // iOS Safari exposes standalone as a non-standard navigator property
+    (navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
+function isIOS(): boolean {
+  const ua = navigator.userAgent;
+  // iPadOS 13+ reports itself as Mac, but Macs don't have multi-touch
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (ua.includes('Mac') && navigator.maxTouchPoints > 1)
+  );
+}
+
+function isMobile(): boolean {
+  return /Android|iPad|iPhone|iPod/.test(navigator.userAgent) || isIOS();
+}
+
+export function InstallPrompt() {
+  const [mode, setMode] = useState<'hidden' | 'native' | 'ios'>('hidden');
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    if (isStandalone() || isSnoozed() || !isMobile()) return;
+
+    if (isIOS()) {
+      // No install API on iOS — show "Lägg till på hemskärmen" instructions,
+      // slightly delayed so it doesn't compete with the page loading in.
+      const timer = setTimeout(() => setMode('ios'), 2500);
+      return () => clearTimeout(timer);
+    }
+
+    function handleBeforeInstallPrompt(e: Event) {
+      e.preventDefault();
+      setInstallEvent(e as BeforeInstallPromptEvent);
+      setMode('native');
+    }
+    function handleInstalled() {
+      try { localStorage.setItem(DISMISS_KEY, 'installed'); } catch { /* ignore */ }
+      setMode('hidden');
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleInstalled);
+    };
+  }, []);
+
+  function dismiss() {
+    try { localStorage.setItem(DISMISS_KEY, String(Date.now())); } catch { /* ignore */ }
+    setMode('hidden');
+  }
+
+  async function handleInstall() {
+    if (!installEvent) return;
+    await installEvent.prompt();
+    const { outcome } = await installEvent.userChoice;
+    if (outcome === 'accepted') {
+      try { localStorage.setItem(DISMISS_KEY, 'installed'); } catch { /* ignore */ }
+    }
+    setMode('hidden');
+    setInstallEvent(null);
+  }
+
+  if (mode === 'hidden') return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Installera Önskestjärnan"
+      className="fixed inset-x-0 z-50 px-4"
+      style={{ bottom: 'max(16px, env(safe-area-inset-bottom))' }}
+    >
+      <div
+        className="mx-auto w-full max-w-md rounded-2xl p-4 flex flex-col gap-3"
+        style={{
+          background: '#fff',
+          color: 'var(--color-ink-light)',
+          boxShadow: '0 8px 32px rgba(28, 27, 46, 0.25)',
+          border: '1px solid var(--color-border-light)',
+        }}
+      >
+        <div className="flex items-center gap-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/icons/icon-192.png"
+            alt=""
+            width={44}
+            height={44}
+            className="rounded-xl shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <p className="font-display font-bold text-[15px] leading-tight">
+              Lägg till Önskestjärnan på hemskärmen
+            </p>
+            <p className="text-[12px] mt-0.5" style={{ color: 'var(--color-muted-light)' }}>
+              Snabbare att öppna — som en riktig app, med egen ikon.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Stäng"
+            className="shrink-0 flex items-center justify-center min-h-[36px] min-w-[36px] rounded-full text-[16px] leading-none"
+            style={{ color: 'var(--color-muted-light)', background: 'var(--color-bg-light)' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {mode === 'native' ? (
+          <button type="button" onClick={handleInstall} className="light-cta w-full">
+            Installera appen
+          </button>
+        ) : (
+          <p
+            className="text-[13px] rounded-xl px-3 py-2.5"
+            style={{ background: 'var(--color-accent-soft)', color: 'var(--color-ink-light)' }}
+          >
+            Tryck på <strong>Dela</strong>-knappen{' '}
+            <span aria-hidden="true" style={{ display: 'inline-block', transform: 'translateY(-1px)' }}>
+              {/* iOS share glyph */}
+              <svg width="13" height="16" viewBox="0 0 13 16" fill="none" aria-hidden="true">
+                <path d="M6.5 1v9M3.5 3.5 6.5 1l3 2.5" stroke="var(--color-accent)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M2 6.5H1v8.5h11V6.5h-1" stroke="var(--color-accent)" strokeWidth="1.4" strokeLinecap="round" />
+              </svg>
+            </span>{' '}
+            i webbläsaren och välj <strong>”Lägg till på hemskärmen”</strong>.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- New InstallPrompt banner: native install via beforeinstallprompt on
  Android/Chrome, add-to-home-screen instructions on iOS, hidden when
  already installed and snoozed 14 days on dismiss
- Viewer page: quick-switch chips between children, child name shown
  in header, fallback title "<Barn>s önskelista" instead of
  "Namnlös önskelista", state reset on switch so lists don't bleed
  into each other
- Viewer page: stable name-fetch callbacks (ref-based dedupe) so item/
  status subscriptions no longer tear down on every name fetch
- Dashboard: children sorted by soonest upcoming occasion, then name
- Settings page: shows which child's list is being managed

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QnWt7weLJnQEQpPkJzbiqq