### PR TITLE
fix(photos): make photo decoding work on iOS Safari

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -15,15 +15,56 @@ export function isValidPhotoDataUrl(value: string): boolean {
   );
 }
 
-async function loadImage(file: File): Promise<HTMLImageElement> {
+interface LoadedImage {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  cleanup: () => void;
+}
+
+// iOS Safari note: HTMLImageElement.decode() intermittently rejects large
+// images (12 MP+ camera photos) even though they are fine, so this never
+// calls decode(). Preferred path is createImageBitmap (no such size issue);
+// fallback is <img> with onload, keeping the object URL alive until the
+// caller has finished drawing (Safari may decode lazily at draw time).
+async function loadImage(file: File): Promise<LoadedImage> {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      let bitmap: ImageBitmap;
+      try {
+        bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+      } catch {
+        // Older Safari rejects the options bag — retry without it.
+        bitmap = await createImageBitmap(file);
+      }
+      return {
+        source: bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        cleanup: () => bitmap.close(),
+      };
+    } catch {
+      // Fall through to the <img> path (e.g. formats createImageBitmap rejects).
+    }
+  }
+
   const url = URL.createObjectURL(file);
   try {
-    const img = new Image();
-    img.src = url;
-    await img.decode();
-    return img;
-  } finally {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error('Image decode failed'));
+      el.src = url;
+    });
+    return {
+      source: img,
+      width: img.naturalWidth,
+      height: img.naturalHeight,
+      cleanup: () => URL.revokeObjectURL(url),
+    };
+  } catch (err) {
     URL.revokeObjectURL(url);
+    throw err;
   }
 }
 
@@ -34,27 +75,31 @@ async function loadImage(file: File): Promise<HTMLImageElement> {
  * compressed under MAX_PHOTO_DATA_CHARS.
  */
 export async function fileToPhotoDataUrl(file: File): Promise<string> {
-  const img = await loadImage(file);
-  for (const maxDim of [800, 640, 480]) {
-    const scale = Math.min(1, maxDim / Math.max(img.naturalWidth, img.naturalHeight));
-    const width = Math.max(1, Math.round(img.naturalWidth * scale));
-    const height = Math.max(1, Math.round(img.naturalHeight * scale));
+  const { source, width: srcWidth, height: srcHeight, cleanup } = await loadImage(file);
+  try {
+    for (const maxDim of [800, 640, 480]) {
+      const scale = Math.min(1, maxDim / Math.max(srcWidth, srcHeight));
+      const width = Math.max(1, Math.round(srcWidth * scale));
+      const height = Math.max(1, Math.round(srcHeight * scale));
 
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('Canvas is not supported');
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('Canvas is not supported');
 
-    // JPEG has no alpha channel — flatten transparency onto white.
-    ctx.fillStyle = '#fff';
-    ctx.fillRect(0, 0, width, height);
-    ctx.drawImage(img, 0, 0, width, height);
+      // JPEG has no alpha channel — flatten transparency onto white.
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, width, height);
+      ctx.drawImage(source, 0, 0, width, height);
 
-    for (const quality of [0.8, 0.7, 0.6, 0.5]) {
-      const dataUrl = canvas.toDataURL('image/jpeg', quality);
-      if (dataUrl.length <= MAX_PHOTO_DATA_CHARS) return dataUrl;
+      for (const quality of [0.8, 0.7, 0.6, 0.5]) {
+        const dataUrl = canvas.toDataURL('image/jpeg', quality);
+        if (dataUrl.length <= MAX_PHOTO_DATA_CHARS) return dataUrl;
+      }
     }
+    throw new Error('Could not compress image under the size limit');
+  } finally {
+    cleanup();
   }
-  throw new Error('Could not compress image under the size limit');
 }


### PR DESCRIPTION
## Summary

Fixes "Kunde inte läsa bilden. Prova ett annat foto." when adding an own photo from an iPhone.

**Root cause:** the photo pipeline used `HTMLImageElement.decode()`, which intermittently rejects large images (12 MP+ camera photos) on iOS Safari even though the image is fine.

### Changes (`src/lib/image.ts` only)

- Prefer `createImageBitmap` for decoding (no size-related failures), requesting EXIF orientation via `{ imageOrientation: 'from-image' }` with a retry without the options bag for older Safari
- Fallback path uses `<img>` with `onload` instead of `decode()`, and keeps the object URL alive until drawing has finished (Safari may decode lazily at draw time)

### Verification

Ran the real module in headless Chromium:
- 4032×3024 JPEG (1.3 MB, iPhone camera size) compresses under the 300k char cap via **both** the `createImageBitmap` path and the `<img>` fallback path
- Transparent PNG still flattens to white JPEG; non-image files still reject cleanly
- Typecheck, lint and unit tests green

No security-rules changes — no `firebase deploy` needed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjA9JsbpUX69FVbvdYxmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjA9JsbpUX69FVbvdYxmv)_